### PR TITLE
Updated function definition causing 500 error

### DIFF
--- a/Attribute/SubscribedService.php
+++ b/Attribute/SubscribedService.php
@@ -26,8 +26,5 @@ final class SubscribedService
      * @param string|null $key The key to use for the service
      *                         If null, use "ClassName::methodName"
      */
-    public function __construct(
-        public ?string $key = null
-    ) {
-    }
+    public function __construct(?string $key = null) {}
 }


### PR DESCRIPTION
I had an issue with one of my projects where this file was causing [laravel-opcache](https://github.com/appstract/laravel-opcache) to throw a 500 error.

> syntax error, unexpected 'public' (T_PUBLIC), expecting variable (T_VARIABLE) {"url":"/opcache-api/compile","exception":"[object] (Symfony\Component\Debug\Exception\FatalThrowableError(code: 0): syntax error, unexpected 'public' (T_PUBLIC), expecting variable (T_VARIABLE) at vendor/symfony/service-contracts/Attribute/SubscribedService.php:30)

After removing public from the function definition, everything worked as expected.

This is to correct the following issue - https://github.com/symfony/symfony/issues/44924