### PR TITLE
Exclude test directory from classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "symfony/service-implementation": ""
     },
     "autoload": {
-        "psr-4": { "Symfony\\Contracts\\Service\\": "" }
+        "psr-4": { "Symfony\\Contracts\\Service\\": "" },
+        "exclude-from-classmap": ["/Test/"]
     },
     "minimum-stability": "dev",
     "extra": {


### PR DESCRIPTION
I noticed that the testcase was included in our optimized classmap, this should fix the issue.